### PR TITLE
Status Codes and Message Structure

### DIFF
--- a/src/main/java/com/yshimou/http/HttpMessage.java
+++ b/src/main/java/com/yshimou/http/HttpMessage.java
@@ -1,0 +1,5 @@
+package com.yshimou.http;
+
+public abstract class HttpMessage {
+
+}

--- a/src/main/java/com/yshimou/http/HttpMethod.java
+++ b/src/main/java/com/yshimou/http/HttpMethod.java
@@ -1,0 +1,5 @@
+package com.yshimou.http;
+
+public enum HttpMethod {
+  GET, HEAD;
+}

--- a/src/main/java/com/yshimou/http/HttpParser.java
+++ b/src/main/java/com/yshimou/http/HttpParser.java
@@ -4,12 +4,49 @@ import org.slf4j.LoggerFactory;
 
 import org.slf4j.Logger;
 
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class HttpParser {
 
   private final static Logger log = LoggerFactory.getLogger(HttpParser.class);
 
-  public void parseHttpRequest(InputStream inputStream) {
+  private static final int SP = 0x20;
+
+  private static final int CR = 0x0D;
+
+  private static final int LF = 0x0A;
+
+
+  public HttpRequest parseHttpRequest(InputStream inputStream) throws IOException {
+    InputStreamReader reader = new InputStreamReader(inputStream, StandardCharsets.US_ASCII);
+
+    HttpRequest request = new HttpRequest();
+    parseRequestLine(reader, request);
+    parseHeaders(reader, request);
+    parseBody(reader,request);
+
+    return request;
+  }
+
+  private void parseBody(InputStreamReader reader, HttpRequest request) {
+  }
+
+  private void parseHeaders(InputStreamReader reader, HttpRequest request) {
+    
+  }
+
+  private void parseRequestLine(InputStreamReader reader, HttpRequest request) throws IOException {
+    int _byte;
+    while ((_byte = reader.read()) >= 0) {
+      if(_byte == CR) {
+        _byte = reader.read();
+        if(_byte == LF) {
+          return ;
+        }
+      }
+    }
   }
 }

--- a/src/main/java/com/yshimou/http/HttpParsingException.java
+++ b/src/main/java/com/yshimou/http/HttpParsingException.java
@@ -1,0 +1,15 @@
+package com.yshimou.http;
+
+public class HttpParsingException extends Exception{
+
+  private final HttpStatusCode errorCode;
+
+  public HttpParsingException(HttpStatusCode errorCode) {
+    super(errorCode.MESSAGE);
+    this.errorCode = errorCode;
+  }
+
+  public HttpStatusCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/src/main/java/com/yshimou/http/HttpRequest.java
+++ b/src/main/java/com/yshimou/http/HttpRequest.java
@@ -1,0 +1,22 @@
+package com.yshimou.http;
+
+public class HttpRequest extends HttpMessage{
+
+  private String method ;
+
+  private String requestTarget;
+
+  private String httpVersion;
+
+  public String getMethod() {
+    return method;
+  }
+
+  protected void setMethod(String method) {
+    this.method = method;
+  }
+
+  protected HttpRequest() {
+
+  }
+}

--- a/src/main/java/com/yshimou/http/HttpStatusCode.java
+++ b/src/main/java/com/yshimou/http/HttpStatusCode.java
@@ -1,0 +1,21 @@
+package com.yshimou.http;
+
+public enum HttpStatusCode {
+
+  /* --- CLIENT ERRORS --- */
+  CLIENT_ERROR_400_BAD_REQUEST(400, "Bad Request"),
+  CLIENT_ERROR_401_METHOD_NOT_ALLOWED(401, "Method Not Allowed"),
+  CLIENT_ERROR_414_URI_TOO_LONG(414, "URI Too Long"),
+
+  /* --- SERVER ERRORS --- */
+  SERVER_ERROR_500_INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+  SERVER_ERROR_501_NOT_IMPLEMENTED(501, "Not Implemented");
+
+  public final int STATUS_CODE;
+  public final String MESSAGE;
+
+  HttpStatusCode(int STATUS_CODE, String MESSAGE) {
+    this.STATUS_CODE = STATUS_CODE;
+    this.MESSAGE = MESSAGE;
+  }
+}

--- a/src/test/java/com/yshimou/http/HttpParserTest.java
+++ b/src/test/java/com/yshimou/http/HttpParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
@@ -17,7 +18,7 @@ class HttpParserTest {
   }
 
   @Test
-  void parseHttpRequest() {
+  void parseHttpRequest() throws IOException {
     httpParser.parseHttpRequest(generateValidTestCase());
   }
 


### PR DESCRIPTION
added logic to the parser to take in consideration 
request Line
Headers
Body

For now we're focusing only on requestLine, which should contain the request method (GET, HEAD) :

Implementing also the error messages as well :
CLIENT ERRORS (400,401 & 414) and SERVER ERRORS(500 & 501)